### PR TITLE
Fix 500 error when updating Hackathon with an empty timezone

### DIFF
--- a/pages/[slug]/index.tsx
+++ b/pages/[slug]/index.tsx
@@ -80,12 +80,12 @@ export default function Hackathon({
           <h3>
             {hackathon.startDate &&
               new Date(hackathon.startDate).toLocaleDateString("en-US", {
-                timeZone: hackathon.timezone ?? undefined
+                timeZone: hackathon.timezone || undefined
               })}
             {" to "}
             {hackathon.endDate &&
               new Date(hackathon.endDate).toLocaleDateString("en-US", {
-                timeZone: hackathon.timezone ?? undefined
+                timeZone: hackathon.timezone || undefined
               })}{" "}
           </h3>
           <div

--- a/pages/[slug]/settings.tsx
+++ b/pages/[slug]/settings.tsx
@@ -75,7 +75,7 @@ export default function Hackathon({
                             new Date(hackathon.startDate).toLocaleString(
                               "en-US",
                               {
-                                timeZone: hackathon.timezone ?? undefined
+                                timeZone: hackathon.timezone || undefined
                               }
                             )
                           )
@@ -92,7 +92,7 @@ export default function Hackathon({
                             new Date(hackathon.endDate).toLocaleString(
                               "en-US",
                               {
-                                timeZone: hackathon.timezone ?? undefined
+                                timeZone: hackathon.timezone || undefined
                               }
                             )
                           )
@@ -111,7 +111,7 @@ export default function Hackathon({
                     value: t
                   })),
                   placeholder: "America/Los_Angeles",
-                  defaultValue: hackathon.timezone ?? undefined
+                  defaultValue: hackathon.timezone || undefined
                 },
                 {
                   type: "text",


### PR DESCRIPTION
Currently, when `hackathon.timezone` is an empty string, most hackathon pages throw a 500 error